### PR TITLE
Punctuator recognition

### DIFF
--- a/lexer.cpp
+++ b/lexer.cpp
@@ -199,7 +199,7 @@ void Lexer:: tokenize(){
 	for(it = lines.begin(); it != lines.end(); it++){
 		temp = *it;
 		for(int i = 0; i < temp.size(); i++){
-			if(temp[i] == ' '){
+			if(temp[i] == ' ' || temp[i] == '\t'){
 				continue;
 			}
 			else if(temp[i] == '/' && (i+1) < temp.size() && temp[i+1] == '/'){


### PR DESCRIPTION
Previously : \t\t} was recognised as a literal
Now: \t\t} is just recognised as a punctuator.